### PR TITLE
Scala/open-repl check buffer before kill

### DIFF
--- a/modules/lang/scala/autoload.el
+++ b/modules/lang/scala/autoload.el
@@ -41,7 +41,7 @@ Meant to be used for `scala-mode's `comment-line-break-function'."
   (if (and (require 'sbt-mode nil t)
            (sbt:find-root))
       (let ((buffer-name (sbt:buffer-name)))
-        (unless (comint-check-proc buffer-name)
+        (when (and (get-buffer buffer-name) (not (comint-check-proc buffer-name)))
           (kill-buffer buffer-name))
         (run-scala)
         (get-buffer buffer-name))


### PR DESCRIPTION
# tldr
The `scala/open-repl` method doesn't work if the repl buffer doesn't exist; fails trying to kill the non-existant buffer

<details>
<summary>scala/open-repl debug trace</summary>

```lisp
  kill-buffer("*sbt*<~/src/samspills/silly-graph/>")
  (if (comint-check-proc buffer-name) nil (kill-buffer buffer-name))
  (let ((buffer-name (sbt:buffer-name))) (if (comint-check-proc buffer-name) nil (kill-buffer buffer-name)) (run-scala) (get-buffer buffer-name))
  (if (and (require 'sbt-mode nil t) (sbt:find-root)) (let ((buffer-name (sbt:buffer-name))) (if (comint-check-proc buffer-name) nil (kill-buffer buffer-name)) (run-scala) (get-buffer buffer-name)) (let* ((buffer-name "*scala-repl") (buffer (if (comint-check-proc buffer-name) (get-buffer buffer-name) (make-comint-in-buffer "scala-repl" buffer-name "scala")))) (display-buffer buffer) buffer))
  +scala/open-repl()
  funcall-interactively(+scala/open-repl)
  call-interactively(+scala/open-repl)
  (if (commandp fn) (call-interactively fn) (funcall fn))
  (progn (if (commandp fn) (call-interactively fn) (funcall fn)))
  (unwind-protect (progn (if (commandp fn) (call-interactively fn) (funcall fn))) (set-window-configuration wconfig))
  (let ((wconfig (current-window-configuration))) (unwind-protect (progn (if (commandp fn) (call-interactively fn) (funcall fn))) (set-window-configuration wconfig)))
  (setq buffer (let ((wconfig (current-window-configuration))) (unwind-protect (progn (if (commandp fn) (call-interactively fn) (funcall fn))) (set-window-configuration wconfig))))
  (if (buffer-live-p buffer) buffer (setq buffer (let ((wconfig (current-window-configuration))) (unwind-protect (progn (if (commandp fn) (call-interactively fn) (funcall fn))) (set-window-configuration wconfig)))) (cond ((null buffer) (error "REPL handler %S couldn't open the REPL buffer" fn)) ((not (bufferp buffer)) (error "REPL handler %S failed to return a buffer" fn))) (save-current-buffer (set-buffer buffer) (if plist (progn (setq +eval-repl-plist plist))) (+eval-repl-mode 1)) (puthash key buffer +eval-repl-buffers) buffer)
  (funcall (or displayfn #'get-buffer-create) (if (buffer-live-p buffer) buffer (setq buffer (let ((wconfig (current-window-configuration))) (unwind-protect (progn (if (commandp fn) (call-interactively fn) (funcall fn))) (set-window-configuration wconfig)))) (cond ((null buffer) (error "REPL handler %S couldn't open the REPL buffer" fn)) ((not (bufferp buffer)) (error "REPL handler %S failed to return a buffer" fn))) (save-current-buffer (set-buffer buffer) (if plist (progn (setq +eval-repl-plist plist))) (+eval-repl-mode 1)) (puthash key buffer +eval-repl-buffers) buffer))
  (setq buffer (funcall (or displayfn #'get-buffer-create) (if (buffer-live-p buffer) buffer (setq buffer (let ((wconfig (current-window-configuration))) (unwind-protect (progn (if ... ... ...)) (set-window-configuration wconfig)))) (cond ((null buffer) (error "REPL handler %S couldn't open the REPL buffer" fn)) ((not (bufferp buffer)) (error "REPL handler %S failed to return a buffer" fn))) (save-current-buffer (set-buffer buffer) (if plist (progn (setq +eval-repl-plist plist))) (+eval-repl-mode 1)) (puthash key buffer +eval-repl-buffers) buffer)))
  (if (or (eq buffer (current-buffer)) (null fn)) nil (setq buffer (funcall (or displayfn #'get-buffer-create) (if (buffer-live-p buffer) buffer (setq buffer (let ((wconfig ...)) (unwind-protect (progn ...) (set-window-configuration wconfig)))) (cond ((null buffer) (error "REPL handler %S couldn't open the REPL buffer" fn)) ((not (bufferp buffer)) (error "REPL handler %S failed to return a buffer" fn))) (save-current-buffer (set-buffer buffer) (if plist (progn (setq +eval-repl-plist plist))) (+eval-repl-mode 1)) (puthash key buffer +eval-repl-buffers) buffer))))
  (let* ((project-root (doom-project-root)) (key (cons major-mode project-root)) (buffer (gethash key +eval-repl-buffers))) (progn (or (or (bufferp buffer) (null buffer)) (signal 'wrong-type-argument (list '(or buffer null) buffer 'buffer))) nil) (if (or (eq buffer (current-buffer)) (null fn)) nil (setq buffer (funcall (or displayfn #'get-buffer-create) (if (buffer-live-p buffer) buffer (setq buffer (let (...) (unwind-protect ... ...))) (cond ((null buffer) (error "REPL handler %S couldn't open the REPL buffer" fn)) ((not ...) (error "REPL handler %S failed to return a buffer" fn))) (save-current-buffer (set-buffer buffer) (if plist (progn ...)) (+eval-repl-mode 1)) (puthash key buffer +eval-repl-buffers) buffer)))) (if (bufferp buffer) (progn (save-current-buffer (set-buffer buffer) (if (or (derived-mode-p 'term-mode) (eq (current-local-map) (and ... term-raw-map))) nil (goto-char (if (and ... ...) (cdr comint-last-prompt) (point-max))))) buffer)))
  +eval--ensure-in-repl-buffer(+scala/open-repl (:persist t) pop-to-buffer)
  (set-buffer (+eval--ensure-in-repl-buffer fn plist displayfn))
  (save-current-buffer (set-buffer (+eval--ensure-in-repl-buffer fn plist displayfn)) (if (and (boundp 'evil-mode) evil-mode) (progn (call-interactively #'evil-append-line))) (if region (progn (insert region))) t)
  (let ((region (if (use-region-p) (buffer-substring-no-properties (region-beginning) (region-end))))) (if (commandp fn) nil (error "Couldn't find a valid REPL for %s" major-mode)) (save-current-buffer (set-buffer (+eval--ensure-in-repl-buffer fn plist displayfn)) (if (and (boundp 'evil-mode) evil-mode) (progn (call-interactively #'evil-append-line))) (if region (progn (insert region))) t))
  (progn (if (or (not fn) prompt-p) (progn (let* ((choices (or (let* ... ... ...) (user-error "There are no known available REPLs"))) (choice (or (completing-read "Open a REPL for: " choices) (user-error "Aborting"))) (choice-split (split-string choice " " t)) (module (car choice-split)) (repl (substring (car ...) 1 -1))) (setq fn (intern-soft (format "+%s/open-%srepl" module (if ... "" repl))))))) (let ((region (if (use-region-p) (buffer-substring-no-properties (region-beginning) (region-end))))) (if (commandp fn) nil (error "Couldn't find a valid REPL for %s" major-mode)) (save-current-buffer (set-buffer (+eval--ensure-in-repl-buffer fn plist displayfn)) (if (and (boundp 'evil-mode) evil-mode) (progn (call-interactively #'evil-append-line))) (if region (progn (insert region))) t)))
  (let* ((plist (or (assq major-mode +eval-repls) (list nil nil))) (_mode (if (cdr plist) (car-safe (prog1 plist (setq plist (cdr plist)))) (signal 'wrong-number-of-arguments (list '(_mode fn . plist) (length plist))))) (fn (car-safe (prog1 plist (setq plist (cdr plist)))))) (progn (if (or (not fn) prompt-p) (progn (let* ((choices (or ... ...)) (choice (or ... ...)) (choice-split (split-string choice " " t)) (module (car choice-split)) (repl (substring ... 1 -1))) (setq fn (intern-soft (format "+%s/open-%srepl" module ...)))))) (let ((region (if (use-region-p) (buffer-substring-no-properties (region-beginning) (region-end))))) (if (commandp fn) nil (error "Couldn't find a valid REPL for %s" major-mode)) (save-current-buffer (set-buffer (+eval--ensure-in-repl-buffer fn plist displayfn)) (if (and (boundp 'evil-mode) evil-mode) (progn (call-interactively #'evil-append-line))) (if region (progn (insert region))) t))))
  +eval-open-repl(nil pop-to-buffer)
  +eval/open-repl-other-window(nil)
  funcall-interactively(+eval/open-repl-other-window nil)
  call-interactively(+eval/open-repl-other-window nil nil)
  command-execute(+eval/open-repl-other-window)
```
</details>

# notes
- `kill-buffer` is called unless `comint-check-proc (buffer-name)` returns true
  - `comint-check-proc` checks if the process is alive; no difference between "not alive" and "doesn't exist" 
- if buffer exists but sbt server has been killed, we want to kill the buffer and call `run-scala` again 
- following works to start a repl when nothing else is open (aka. doesn't call `kill-buffer`)
```lisp
        (if (and (get-buffer buffer-name) (not (comint-check-proc buffer-name)))
          (kill-buffer buffer-name))
        (run-scala)
```
  - if I kill scala repl and sbt server, but leave buffer alive it doesn't get killed?
  - potentially related to `scala/open-repl` being added to `eval-repls` with `:persist t` ?
-  `+eval--ensure-in-repl-buffer` wasn't triggering for a dead sbt server in repl
  - buffer was being returned after a `buffer-live-p` check, which checks buffer not-killed
    - switch to `comint-check-proc` to check that buffer process is alive
  - the `save-window-excursion` was deleting the newly created buffer
    - removed that for now

# todo
- [ ] testing
  - [ ] does this break other repl functionality in other languages? 
    - check other languages set with `:persist t` specifically
  - [ ] check non-sbt scala